### PR TITLE
Micro-Optimization

### DIFF
--- a/StegoHelper/EncryptionHelper.cs
+++ b/StegoHelper/EncryptionHelper.cs
@@ -36,8 +36,8 @@ namespace StegoHelper
                                 byte[] cipherTextBytes = saltStringBytes;
                                 cipherTextBytes = cipherTextBytes.Concat(ivStringBytes).ToArray();
                                 cipherTextBytes = cipherTextBytes.Concat(memoryStream.ToArray()).ToArray();
-                                memoryStream.Close();
-                                cryptoStream.Close();
+                                //memoryStream.Close();
+                                //cryptoStream.Close();
 
                                 return Convert.ToBase64String(cipherTextBytes);
                             }


### PR DESCRIPTION
I removed two closed methods because _using_ keyword already did it.

https://source.dot.net/#System.Private.CoreLib/MemoryStream.cs,1a4dcb744a23ba6f (MemoryStream)

https://source.dot.net/#System.Security.Cryptography/System/Security/Cryptography/CryptoStream.cs,af85dc74cc324e3e (CryptoStream)

Class instances finally invoke Dispose https://source.dot.net/#System.Private.CoreLib/Stream.cs,f956b0c07e86df64 (Stream) so you can avoid this calls.